### PR TITLE
Complete GitHub workflow to release to all platforms

### DIFF
--- a/.github/workflows/github-actions-youtd.yml
+++ b/.github/workflows/github-actions-youtd.yml
@@ -80,7 +80,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: youtd-${{ env.TAG_VERSION }}
-        path: .
+        path: ${{ steps.export.outputs.archive_directory }}/*.zip
         if-no-files-found: error
         retention-days: 1
 

--- a/.github/workflows/github-actions-youtd.yml
+++ b/.github/workflows/github-actions-youtd.yml
@@ -43,7 +43,7 @@ jobs:
     - name: update project.godot with new version
       run: |
         project_godot_file="${{ github.workspace }}/project.godot"
-        sed -i 's/\(config\/version="\).*\("\)/\1'"${TAG_VERSION}"'\2/' "${project_godot_file}"
+        sed -i '' 's/\(config\/version="\).*\("\)/\1'"${TAG_VERSION}"'\2/' "${project_godot_file}"
         echo "New project.godot contents:"
         cat ${{ github.workspace }}/project.godot
 

--- a/.github/workflows/github-actions-youtd.yml
+++ b/.github/workflows/github-actions-youtd.yml
@@ -74,7 +74,7 @@ jobs:
 
     - name: repack web artifact
       run: |
-        zip -ur ${{ steps.export.outputs.archive_directory }}/web.zip ${{ github.workspace }}/Build/Web/*
+        zip -uj ${{ steps.export.outputs.archive_directory }}/web.zip ${{ github.workspace }}/Build/Web/*
 
     - uses: actions/upload-artifact@v3
       with:
@@ -113,7 +113,7 @@ jobs:
       run: |
         VERSION_TAG="${{ needs.export_game.outputs.tag_version }}"
         mv "exported_files/${{ matrix.platform }}.zip" "exported_files/${{ matrix.platform }}-$VERSION_TAG.zip"
-        echo "$platform_artifact=exported_files/$platform-$VERSION_TAG.zip" >> $GITHUB_OUTPUT
+        echo "${{ matrix.platform }}=exported_files/$platform-$VERSION_TAG.zip" >> $GITHUB_OUTPUT
 
     - name: upload artifacts
       id: upload_artifacts

--- a/.github/workflows/github-actions-youtd.yml
+++ b/.github/workflows/github-actions-youtd.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         brew tap homebrew/cask-versions
         brew install --cask --no-quarantine wine-stable
-        echo "WINE_PATH=$(which wine)" >> $GITHUB_OUTPUT
+        echo "WINE_PATH=$(which wine64)" >> $GITHUB_OUTPUT
     
     - name: export game
       id: export
@@ -76,7 +76,7 @@ jobs:
     - name: repack web artifact
       run: |
         zip -uj ${{ steps.export.outputs.archive_directory }}/web.zip ${{ github.workspace }}/Build/Web/*
-        cp ${{ github.workspace }}/Build/Web/* ${{ steps.export.outputs.build_directory }}/
+        cp ${{ github.workspace }}/Build/Web/* ${{ steps.export.outputs.build_directory }}/web/
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/github-actions-youtd.yml
+++ b/.github/workflows/github-actions-youtd.yml
@@ -83,7 +83,6 @@ jobs:
         name: youtd-${{ env.TAG_VERSION }}
         path: ${{ steps.export.outputs.archive_directory }}/*.zip
         if-no-files-found: error
-        retention-days: 1
 
     - name: deploy to github pages
       if: steps.export.outcome == 'success'
@@ -141,6 +140,10 @@ jobs:
             echo "Commit ref: $GITHUB_REF_NAME"
             echo "Release tag: ${{ needs.export_game.outputs.commit_ref }}"
         
+        - uses: geekyeggo/delete-artifact@v2
+          with:
+            name: youtd-${{ needs.export_game.outputs.tag_version }}
+
         - name: download artifacts
           uses: actions/download-artifact@v3
           with:
@@ -156,4 +159,4 @@ jobs:
             token: ${{ secrets.GITHUB_TOKEN }}
             tag: ${{ needs.export_game.outputs.commit_ref }}
             generateReleaseNotes: true
-            artifacts: ./*
+            artifacts: ./**/*

--- a/.github/workflows/github-actions-youtd.yml
+++ b/.github/workflows/github-actions-youtd.yml
@@ -63,7 +63,7 @@ jobs:
       id: export
       uses: firebelley/godot-export@v5.0.0
       with:
-        godot_executable_download_url: https://github.com/godotengine/godot/releases/download/4.0.2-stable/Godot_v4.0.2-stable_linux.x86_64.zip
+        godot_executable_download_url: https://github.com/godotengine/godot/releases/download/4.0.2-stable/Godot_v4.0.2-stable_macos.universal.zip
         godot_export_templates_download_url: https://github.com/godotengine/godot/releases/download/4.0.2-stable/Godot_v4.0.2-stable_export_templates.tpz
         relative_project_path: ./
         verbose: true

--- a/.github/workflows/github-actions-youtd.yml
+++ b/.github/workflows/github-actions-youtd.yml
@@ -44,6 +44,7 @@ jobs:
       run: |
         project_godot_file="${{ github.workspace }}/project.godot"
         sed -i '' 's/\(config\/version="\).*\("\)/\1'"${TAG_VERSION}"'\2/' "${project_godot_file}"
+    # sed -i s/\(config\/version="\).*\("\)/\1'"${TAG_VERSION}"'\2/' "${project_godot_file}"
         echo "New project.godot contents:"
         cat ${{ github.workspace }}/project.godot
 
@@ -52,11 +53,18 @@ jobs:
         mkdir -p .config/godot
         cp ${{ github.workspace }}/.github/workflows/editor_settings-4.tres .config/godot/
 
+    # - name: install wine
+    #   id: wine_install
+    #   run: |
+    #     sudo apt install wine64
+    #     echo "WINE_PATH=$(which wine64)" >> $GITHUB_OUTPUT
+
     - name: install wine
       id: wine_install
       run: |
-        sudo apt install wine64
-        echo "WINE_PATH=$(which wine64)" >> $GITHUB_OUTPUT
+        brew tap homebrew/cask-versions
+        brew install --cask --no-quarantine wine-stable
+        echo "WINE_PATH=$(which wine)" >> $GITHUB_OUTPUT
     
     - name: export game
       id: export

--- a/.github/workflows/github-actions-youtd.yml
+++ b/.github/workflows/github-actions-youtd.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   export_game:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     name: export game
     steps:
     - name: checkout
@@ -101,16 +101,7 @@ jobs:
     strategy:
       matrix:
         platform: [windows, macos, web, linux]
-        include:
-          - os_image: windows-latest
-            platform: windows
-          - os_image: macos-latest
-            platform: macos
-          - os_image: ubuntu-latest
-            platform: linux
-          - os_image: windows-latest
-            platform: web
-    runs-on: ${{ matrix.os_image }}
+    runs-on: ubuntu-latest
     steps:
     - name: download exported files
       uses: actions/download-artifact@v3

--- a/.github/workflows/github-actions-youtd.yml
+++ b/.github/workflows/github-actions-youtd.yml
@@ -4,7 +4,7 @@ on:
   push:
     # Sequence of patterns matched against refs/heads
     branches:    
-      - github_actions
+      - main
     # Sequence of patterns matched against refs/tags
     tags:        
       - v*

--- a/.github/workflows/github-actions-youtd.yml
+++ b/.github/workflows/github-actions-youtd.yml
@@ -44,7 +44,6 @@ jobs:
       run: |
         project_godot_file="${{ github.workspace }}/project.godot"
         sed -i '' 's/\(config\/version="\).*\("\)/\1'"${TAG_VERSION}"'\2/' "${project_godot_file}"
-    # sed -i s/\(config\/version="\).*\("\)/\1'"${TAG_VERSION}"'\2/' "${project_godot_file}"
         echo "New project.godot contents:"
         cat ${{ github.workspace }}/project.godot
 
@@ -52,12 +51,6 @@ jobs:
       run: |
         mkdir -p .config/godot
         cp ${{ github.workspace }}/.github/workflows/editor_settings-4.tres .config/godot/
-
-    # - name: install wine
-    #   id: wine_install
-    #   run: |
-    #     sudo apt install wine64
-    #     echo "WINE_PATH=$(which wine64)" >> $GITHUB_OUTPUT
 
     - name: install wine
       id: wine_install

--- a/.github/workflows/github-actions-youtd.yml
+++ b/.github/workflows/github-actions-youtd.yml
@@ -4,7 +4,7 @@ on:
   push:
     # Sequence of patterns matched against refs/heads
     branches:    
-      - main
+      - github_actions
     # Sequence of patterns matched against refs/tags
     tags:        
       - v*
@@ -77,25 +77,15 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: add tags to artifacts
-      working-directory: ${{ steps.export.outputs.archive_directory }}
-      run: |
-        echo "FILES=$(ls -I '' | tr '\n' ' ')" >> $GITHUB_ENV
-        tag_version="${{ env.TAG_VERSION }}"
-        for file in $FILES; do
-          mv "$file" "${file%.zip}-$tag_version.zip"
-        done
-        ls -R .
-      shell: bash
-
     - uses: actions/upload-artifact@v3
       with:
         name: youtd-${{ env.TAG_VERSION }}
-        path: ./*-${{ env.TAG_VERSION }}.zip
+        path: .
         if-no-files-found: error
         retention-days: 1
 
     - name: deploy to github pages
+      if: steps.export.outcome == 'success'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-actions-youtd.yml
+++ b/.github/workflows/github-actions-youtd.yml
@@ -57,11 +57,6 @@ jobs:
       run: |
         sudo apt install wine64
         echo "WINE_PATH=$(which wine64)" >> $GITHUB_OUTPUT
-
-    - name: copy additional web assets
-      run: |
-        mkdir -p /home/runner/.local/share/godot/build/web/
-        cp -R ${{ github.workspace }}/Build/Web/* /home/runner/.local/share/godot/build/web/
     
     - name: export game
       id: export
@@ -77,6 +72,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: repack web artifact
+      run: |
+        zip -ur ${{ steps.export.outputs.archive_directory }}/web.zip ${{ github.workspace }}/Build/Web/*
+
     - uses: actions/upload-artifact@v3
       with:
         name: youtd-${{ env.TAG_VERSION }}
@@ -89,7 +88,7 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ${{ steps.export.outputs.build_directory }}
+        publish_dir: ${{ steps.export.outputs.build_directory }}/web
 
     outputs:
       tag_version: ${{ env.TAG_VERSION }}

--- a/.github/workflows/github-actions-youtd.yml
+++ b/.github/workflows/github-actions-youtd.yml
@@ -75,6 +75,7 @@ jobs:
     - name: repack web artifact
       run: |
         zip -uj ${{ steps.export.outputs.archive_directory }}/web.zip ${{ github.workspace }}/Build/Web/*
+        cp ${{ github.workspace }}/Build/Web/* ${{ steps.export.outputs.build_directory }}/
 
     - uses: actions/upload-artifact@v3
       with:
@@ -97,10 +98,19 @@ jobs:
 
   upload_artifacts:
     needs: export_game
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: ['windows', 'macos', 'web', 'linux']
+        platform: [windows, macos, web, linux]
+        include:
+          - os_image: windows-latest
+            platform: windows
+          - os_image: macos-latest
+            platform: macos
+          - os_image: ubuntu-latest
+            platform: linux
+          - os_image: windows-latest
+            platform: web
+    runs-on: ${{ matrix.os_image }}
     steps:
     - name: download exported files
       uses: actions/download-artifact@v3


### PR DESCRIPTION
Currently supported platforms are: linux, windows, macos, web. Artifacts are build using `macos-latest` image.