### PR TITLE
Add IdentityProvider and use it to retrieve logged-in user from itch.io

### DIFF
--- a/.itch.toml
+++ b/.itch.toml
@@ -1,0 +1,3 @@
+[[actions]]
+name = "YouTD2"
+scope = "profile:me"

--- a/Scenes/HUD/WaveStatus.gd
+++ b/Scenes/HUD/WaveStatus.gd
@@ -171,3 +171,4 @@ func _on_identity_request_completed(result, response_code, headers, body):
 		push_error("Error occurred while to get an identity: %s" % json["errors"])
 	else:
 		_username_label.text = json["user"]["username"]
+		_username_label.show()

--- a/Scenes/HUD/WaveStatus.gd
+++ b/Scenes/HUD/WaveStatus.gd
@@ -168,7 +168,7 @@ func _on_update_stats_timer_timeout():
 func _on_identity_request_completed(result, response_code, headers, body):
 	var json: Dictionary = JSON.parse_string(body.get_string_from_utf8())
 	if json.has("errors"):
-		push_error("Error occurred while to get an identity: %s" % json["errors"])
+		push_error("Error occurred while trying to get an identity: %s" % json["errors"])
 	else:
 		_username_label.text = json["user"]["username"]
 		_username_label.show()

--- a/Scenes/HUD/WaveStatus.tscn
+++ b/Scenes/HUD/WaveStatus.tscn
@@ -52,6 +52,7 @@ accept_gzip = false
 timeout = 5.0
 
 [node name="UsernameLabel" type="Label" parent="."]
+visible = false
 layout_mode = 2
 text = "username"
 horizontal_alignment = 1

--- a/Scenes/HUD/WaveStatus.tscn
+++ b/Scenes/HUD/WaveStatus.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Theme" uid="uid://bql5sxaowafw3" path="res://Resources/Theme/wc3_theme.tres" id="1_3h6gw"]
 [ext_resource type="Script" path="res://Scenes/HUD/WaveStatus.gd" id="2_fsc15"]
 
-[node name="WaveStatus" type="VBoxContainer" node_paths=PackedStringArray("_label", "_stats_label", "_timer_label")]
+[node name="WaveStatus" type="VBoxContainer" node_paths=PackedStringArray("_label", "_stats_label", "_timer_label", "_username_label", "_http_request")]
 offset_right = 600.0
 offset_bottom = 134.0
 theme = ExtResource("1_3h6gw")
@@ -11,6 +11,8 @@ script = ExtResource("2_fsc15")
 _label = NodePath("DetailsLabel")
 _stats_label = NodePath("StatsLabel")
 _timer_label = NodePath("TimerLabel")
+_username_label = NodePath("UsernameLabel")
+_http_request = NodePath("GetIdentity")
 
 [node name="TimerLabel" type="RichTextLabel" parent="."]
 layout_mode = 2
@@ -44,5 +46,14 @@ autowrap_mode = 0
 
 [node name="UpdateStatsTimer" type="Timer" parent="."]
 autostart = true
+
+[node name="GetIdentity" type="HTTPRequest" parent="."]
+accept_gzip = false
+timeout = 5.0
+
+[node name="UsernameLabel" type="Label" parent="."]
+layout_mode = 2
+text = "username"
+horizontal_alignment = 1
 
 [connection signal="timeout" from="UpdateStatsTimer" to="." method="_on_update_stats_timer_timeout"]

--- a/Singletons/IdentityProviders.gd
+++ b/Singletons/IdentityProviders.gd
@@ -1,0 +1,26 @@
+extends Node
+
+
+class IdentityProvider:
+	var _api_key: String
+	
+	func _init(api_key):
+		_api_key = api_key
+	
+	func get_identity():
+		pass
+
+
+class ItchIndentityProvider extends IdentityProvider:
+	
+	var _http_request: HTTPRequest
+	
+	func _init(http_request: HTTPRequest):
+		_api_key = "c84OMEkW9gub0tSc6tdG0dkJ0yjqF3tY2bS0jmgt"
+		_http_request = http_request
+	
+	func get_identity():
+		var auth_header = [ "Authorization: Bearer %s" % _api_key] 
+		var res = _http_request.request("https://itch.io/api/1/key/me", auth_header)
+		if res != OK:
+			push_error("Could not retrieve identity for itch.io provider.")

--- a/Singletons/IdentityProviders.gd
+++ b/Singletons/IdentityProviders.gd
@@ -16,7 +16,7 @@ class ItchIndentityProvider extends IdentityProvider:
 	var _http_request: HTTPRequest
 	
 	func _init(http_request: HTTPRequest):
-		_api_key = "c84OMEkW9gub0tSc6tdG0dkJ0yjqF3tY2bS0jmgt"
+		_api_key = OS.get_environment("ITCHIO_API_KEY")
 		_http_request = http_request
 	
 	func get_identity():

--- a/project.godot
+++ b/project.godot
@@ -105,6 +105,7 @@ PortalLives="*res://Singletons/PortalLives.gd"
 ManualAttackTarget="*res://Singletons/ManualAttackTarget.gd"
 Settings="*res://Singletons/Settings.gd"
 CombatLog="*res://Singletons/CombatLog.gd"
+IdentityProviders="*res://Singletons/IdentityProviders.gd"
 
 [debug]
 


### PR DESCRIPTION
This PR should work for Windows binary, but need to check when upload it to itch.io. 
https://itch.io/docs/api/serverside
https://itch.io/docs/itch/integrating/manifest-actions.html
Logged-in user is shown here, for starters: 
<img width="551" alt="Screenshot 2023-12-08 at 6 13 48 PM" src="https://github.com/Praytic/youtd2/assets/10060411/bf58ab36-e752-4120-a7c7-76f6e2d95d46">
Can show it during pause and integrate with Scoreboard to record how much score players got.