### PR TITLE
Autooil commands QoL

### DIFF
--- a/src/game_scene/chat_commands.gd
+++ b/src/game_scene/chat_commands.gd
@@ -274,17 +274,17 @@ func _require_owner(tower: Tower, player: Player) -> bool:
 		return false
 	return true
 
-func _resolve_autooil_arg(player: Player, option: String) -> bool:
-	var unit = player.get_selected_unit()
+func _resolve_autooil_arg(player: Player, option: String):
+	var unit: Unit = player.get_selected_unit()
 	
 	var tower: Tower = null
-	var tower_name = null
-	var is_tower = _is_tower(unit)
+	var tower_name: String = ""
+	var is_tower: bool = _is_tower(unit)
 	if is_tower:
 		tower = unit as Tower
 		tower_name = tower.get_display_name()
 		
-	var matched = true
+	var matched: bool = true
 	
 	match option:
 		"list":
@@ -305,12 +305,12 @@ func _resolve_autooil_arg(player: Player, option: String) -> bool:
 					player.clear_autooil_for_tower(tower)
 					_add_status(player, "Cleared autooils for %s." % tower_name)
 				else:
-					return false
+					return
 		_:
 			matched = false
 	
 	if matched:
-		return true
+		return
 	
 	if _require_tower(unit, player) and _require_owner(tower, player):
 		var oil_type: String = option
@@ -318,15 +318,15 @@ func _resolve_autooil_arg(player: Player, option: String) -> bool:
 		
 		if not oil_type_is_valid:
 			_add_error(player, "Invalid oil type: \"%s\"." % oil_type)
-			return false
+			return
 		
 		var full_oil_type: String = AutoOil.convert_short_type_to_full(oil_type)
 		player.set_autooil_for_tower(full_oil_type, tower)
 		_add_status(player, "Set autooil for tower [color=GOLD]%s[/color] to [color=GOLD]%s[/color] oils." % [tower_name, full_oil_type])
 	
-		return true
+		return
 	else:
-		return false
+		return
 
 
 func _command_autooil(player: Player, args: Array):

--- a/src/game_scene/chat_commands.gd
+++ b/src/game_scene/chat_commands.gd
@@ -258,7 +258,7 @@ func _command_autospawn(player: Player, args: Array):
 	_add_status_for_team(team, "Set autospawn time to [color=GOLD]%d[/color]." % roundi(autospawn_time))
 
 func _is_tower(unit: Unit) -> bool:
-	# return null if non-tower is selected or unit is null
+	# return false if non-tower is selected or unit is null
 	return unit != null and unit is Tower
 
 func _require_unit(unit: Unit, player: Player) -> bool:

--- a/src/game_scene/chat_commands.gd
+++ b/src/game_scene/chat_commands.gd
@@ -261,15 +261,9 @@ func _is_tower(unit: Unit) -> bool:
 	# return false if non-tower is selected or unit is null
 	return unit != null and unit is Tower
 
-func _require_unit(unit: Unit, player: Player) -> bool:
-	if unit == null:
-		_add_error(player, "You must select a tower to execute this mode of autooil command.")
-		return false
-	return true
-
 func _require_tower(unit: Unit, player: Player) -> bool:
 	if not unit is Tower:
-		_add_error(player, "Cannot autooil while selecting non-tower units.")
+		_add_error(player, "You must select a tower to execute this mode of autooil command.")
 		return false
 	return true
 
@@ -318,7 +312,7 @@ func _resolve_autooil_arg(player: Player, option: String) -> bool:
 	if matched:
 		return true
 	
-	if _require_unit(unit, player) and _require_tower(unit, player) and _require_owner(tower, player):
+	if _require_tower(unit, player) and _require_owner(tower, player):
 		var oil_type: String = option
 		var oil_type_is_valid: bool = AutoOil.get_oil_type_is_valid(oil_type)
 		

--- a/src/game_scene/chat_commands.gd
+++ b/src/game_scene/chat_commands.gd
@@ -286,7 +286,6 @@ func _resolve_autooil_arg(player: Player, option: String) -> bool:
 	var tower: Tower = null
 	var tower_name = null
 	var is_tower = _is_tower(unit)
-	var is_owner = null
 	if is_tower:
 		tower = unit as Tower
 		tower_name = tower.get_display_name()
@@ -304,7 +303,7 @@ func _resolve_autooil_arg(player: Player, option: String) -> bool:
 			_add_status(player, "Autooil status:")
 			Messages.add_normal(player, status_text)
 		"clear":
-			if not _is_tower(unit):
+			if not is_tower:
 				player.clear_all_autooil()
 				_add_status(player, "Cleared all autooils.")
 			else:
@@ -319,7 +318,7 @@ func _resolve_autooil_arg(player: Player, option: String) -> bool:
 	if matched:
 		return true
 	
-	if _require_unit(unit, player) and _require_tower(unit, player):
+	if _require_unit(unit, player) and _require_tower(unit, player) and _require_owner(tower, player):
 		var oil_type: String = option
 		var oil_type_is_valid: bool = AutoOil.get_oil_type_is_valid(oil_type)
 		

--- a/src/player/auto_oil.gd
+++ b/src/player/auto_oil.gd
@@ -18,6 +18,10 @@ const OIL_TYPE_MAP: Dictionary = {
 	"wizard": [1024],
 }
 
+const OIL_TYPE_SYNONYMS: Dictionary = {
+	"accuracy": ["critical"],
+}
+
 var _data: Dictionary = {}
 
 
@@ -154,6 +158,9 @@ static func get_oil_type_is_valid(given_oil_type: String) -> bool:
 
 # Returns empty string if conversion is not possible
 static func convert_short_type_to_full(short_oil_type: String) -> String:
+	if short_oil_type in OIL_TYPE_MAP:
+		return short_oil_type
+	
 	var matching_type_count: int = 0
 	var matching_oil_type: String = ""
 	
@@ -161,6 +168,12 @@ static func convert_short_type_to_full(short_oil_type: String) -> String:
 	
 	for oil_type in oil_type_list:
 		var matches: bool = oil_type.begins_with(short_oil_type)
+		
+		if not matches and oil_type in OIL_TYPE_SYNONYMS:
+			for synonym in OIL_TYPE_SYNONYMS[oil_type]:
+				if synonym.begins_with(short_oil_type):
+					matches = true
+					break
 		
 		if matches:
 			matching_type_count += 1

--- a/src/player/auto_oil.gd
+++ b/src/player/auto_oil.gd
@@ -19,7 +19,14 @@ const OIL_TYPE_MAP: Dictionary = {
 }
 
 const OIL_TYPE_SYNONYMS: Dictionary = {
+	"sharpness": ["damage", "dmg"],
+	"magic": ["mana"],
 	"accuracy": ["critical"],
+	"swiftness": ["speed"],
+	"sorcery": ["spell"],
+	"exuberance": ["bounty"],
+	"seeker": ["item"],
+	"lore": ["experience"],
 }
 
 var _data: Dictionary = {}


### PR DESCRIPTION
refactors autooil chat commands code, adds synonyms to oil names

Allows usage of multiple autooil commands at once and adds synonyms dictionary, currently with single synonym for accuracy - 'critical'. Example usage i.e. /ao sharp swift crit; or even /ao clear sharp swift crit show.