### PR TITLE
Range checks testing issue #472

### DIFF
--- a/src/game_scene/game_client.gd
+++ b/src/game_scene/game_client.gd
@@ -28,7 +28,7 @@ const CHECKSUM_PERIOD_TICKS: int = 30 * GameHost.MULTIPLAYER_TURN_LENGTH
 
 
 var _tick_delta: float
-var _current_tick: int = 0
+static var _current_tick: int = 0
 var _turn_length: int
 # Timeslot buffer determines how many timeslots to keep in
 # buffer. Turns are buffered to avoid getting into

--- a/src/singletons/constants.gd
+++ b/src/singletons/constants.gd
@@ -91,9 +91,9 @@ const BASE_ITEM_DROP_CHANCE: float = 0.0475
 # NOTE: MOVE_SPEED_MIN is 100 because this appears to be the
 # minimum limit applied internaly inside the WC3
 # SetUnitMoveSpeed() function.
-const MOVE_SPEED_MIN: float = 100.0
+const MOVE_SPEED_MIN: float = 50.0
 const MOVE_SPEED_MAX: float = 522.0
-const DEFAULT_MOVE_SPEED: float = 222.0
+const DEFAULT_MOVE_SPEED: float = 50.0
 
 # 24h = 480 irl seconds
 const IRL_SECONDS_TO_GAME_WORLD_HOURS: float = 24.0 / 480.0

--- a/src/singletons/vector_utils.gd
+++ b/src/singletons/vector_utils.gd
@@ -46,7 +46,9 @@ func in_range(start: Vector2, end: Vector2, radius: float) -> bool:
 	var distance_squared: float = start.distance_squared_to(end)
 	var radius_squared: float = radius * radius
 	var result: bool = distance_squared <= radius_squared
-
+	
+	Messages.add_normal(owner, ('Game tick: %s' % GameClient._current_tick) + '\nRadius: %s' % radius + '\nDistance: %s' % distance_squared ** 0.5)
+	
 	return result
 
 

--- a/src/towers/tower.gd
+++ b/src/towers/tower.gd
@@ -416,7 +416,7 @@ func _target_is_valid(target) -> bool:
 	var attack_range: float = get_range() + Constants.RANGE_CHECK_BONUS_FOR_TOWERS
 	
 	# suggested change to fix
-	#attack_range += Utils.apply_unit_range_extension(attack_range, _attack_target_type)
+	# attack_range = Utils.apply_unit_range_extension(attack_range, _attack_target_type)
 	
 	var in_range = VectorUtils.in_range(get_position_wc3_2d(), target.get_position_wc3_2d(), attack_range)
 

--- a/src/towers/tower.gd
+++ b/src/towers/tower.gd
@@ -414,6 +414,10 @@ func _target_is_valid(target) -> bool:
 # 	NOTE: need to extend attack range by "tower radius".
 # 	This is how it works in the original game.
 	var attack_range: float = get_range() + Constants.RANGE_CHECK_BONUS_FOR_TOWERS
+	
+	# suggested change to fix
+	#attack_range += Utils.apply_unit_range_extension(attack_range, _attack_target_type)
+	
 	var in_range = VectorUtils.in_range(get_position_wc3_2d(), target.get_position_wc3_2d(), attack_range)
 
 	var target_is_invisible: bool = target.is_invisible()


### PR DESCRIPTION
**Only for testing setup purposes for #472  - not to merge**

- reduced movement speed of creeps (allows some towers to catch them in range and fire that would otherwise not)
- printing states of range checks for tower (game tick, tower range, creep distance)