### PR TITLE
Expected value of DPS with crit - minor fix and function readability refactor

### DIFF
--- a/src/towers/tower.gd
+++ b/src/towers/tower.gd
@@ -1107,8 +1107,8 @@ func get_dps_with_crit() -> float:
 	var current_dmg_multiplier: float = 1.0
 
 	while multicrit_current > 0:
-		if current_crit_chance > Constants.ATK_MULTICRIT_DIMISHING:
-			current_dmg_multiplier *= Constants.ATK_MULTICRIT_DIMISHING
+		if current_crit_chance > Constants.ATK_CRIT_CHANCE_CAP:
+			current_dmg_multiplier *= Constants.ATK_CRIT_CHANCE_CAP
 		else:
 			current_dmg_multiplier *= current_crit_chance
 

--- a/src/towers/tower.gd
+++ b/src/towers/tower.gd
@@ -1128,7 +1128,7 @@ func get_dps_with_crit() -> float:
 		remaining_multicrits -= 1
 
 	var dps: float = get_overall_dps()
-	var dps_with_crit: float = dps * crit_multiplier
+	var dps_with_crit: float = dps * expected_crit_multiplier
 	
 	return dps_with_crit
 


### PR DESCRIPTION
This fixes:
- expected dps with crit value didn't use ATK_CRIT_CHANCE_CAP (it used ATK_MULTICRIT_DIMISHING in its place - but because they have the same value of 0.8 - the result was correct before)
- clamping crit chance also at 0% (if for any reason crit would go below 0; the expected value would be lower - even tough negative crit wouldn't affect actual damage output)

Overall it probably never changes the outcome, but now seems _**more correct**_.

Also the variables are renamed + comments are added so that it is (in my view) easier to understand calculation logic in the future.