### PR TITLE
Error in language selection

### DIFF
--- a/src/enums/language.gd
+++ b/src/enums/language.gd
@@ -20,6 +20,8 @@ static var language_option_locale_map: Dictionary = {
 	1:"zh",
 }
 
+static var default_language: String = "en"
+
 static func get_locale_from_enum (lan: Language.enm) -> String:
 	return language_map[lan]
 
@@ -27,7 +29,10 @@ static func get_enum_from_option (opt: int) -> Language.enm:
 	return language_option_map[opt]
 
 static func get_option_from_locale (lan: String) -> int:
-	return language_option_locale_map.find_key(lan)
+	var language_option: Variant = language_option_locale_map.find_key(lan)
+	if language_option == null:
+		return language_option_locale_map.find_key(default_language)
+	return int(language_option)
 
 static func get_locale_from_option (opt: int) -> String:
 	return language_option_locale_map[opt]


### PR DESCRIPTION
If os language is other than 'en' or 'zh' 

` static func get_option_from_locale (lan: String) -> int:`

will attempt to return null from `.find_key(lan)` and (I suppose) automatically convert it to 0, but still it triggers breakpoint on 'any error' while debugging. This fixes it and explicitly handles default value for other languages.