### PR TITLE
Attack and spell damage meters

### DIFF
--- a/src/game_scene/chat_commands.gd
+++ b/src/game_scene/chat_commands.gd
@@ -452,7 +452,15 @@ func _command_damage_meters(player: Player, _args: Array):
 		var damage: float = tower.get_total_damage()
 		var damage_string: String = TowerDetails.int_format(damage)
 		
-		Messages.add_normal(player, "%s: [color=GOLD]%s[/color]" % [tower_name, damage_string])
+		var damage_attack: float = tower.get_total_damage_by_type(Tower.DamageSource.Attack)
+		var attack_percentage: float = Utils.divide_safe(damage_attack, damage) * 100
+		var attack_percentage_string: String = Utils.format_float(attack_percentage, 1)
+		
+		var damage_spell: float = tower.get_total_damage_by_type(Tower.DamageSource.Spell)
+		var spell_percentage: float = Utils.divide_safe(damage_spell, damage) * 100
+		var spell_percentage_string: String = Utils.format_float(spell_percentage, 1)
+		
+		Messages.add_normal(player, "%s: [color=GOLD]%s[/color], attack:%s%%, spell: %s%%" % [tower_name, damage_string, attack_percentage_string, spell_percentage_string])
 
 		count += 1
 
@@ -476,10 +484,19 @@ func _command_damage_meters_recent(player: Player, _args: Array):
 			break
 
 		var tower_name: String = tower.get_display_name()
+		
 		var damage: float = tower.get_total_damage_recent()
 		var damage_string: String = TowerDetails.int_format(damage)
 		
-		Messages.add_normal(player, "%s: [color=GOLD]%s[/color]" % [tower_name, damage_string])
+		var damage_attack: float = tower.get_total_damage_recent(true, Tower.DamageSource.Attack)
+		var attack_percentage: float = Utils.divide_safe(damage_attack, damage) * 100
+		var attack_percentage_string: String = Utils.format_float(attack_percentage, 1)
+
+		var damage_spell: float = tower.get_total_damage_recent(true, Tower.DamageSource.Spell)
+		var spell_percentage: float = Utils.divide_safe(damage_spell, damage) * 100
+		var spell_percentage_string: String = Utils.format_float(spell_percentage, 1)
+		
+		Messages.add_normal(player, "%s: [color=GOLD]%s[/color], attack:%s%%, spell: %s%%" % [tower_name, damage_string, attack_percentage_string, spell_percentage_string])
 
 		count += 1
 

--- a/src/game_scene/chat_commands.gd
+++ b/src/game_scene/chat_commands.gd
@@ -450,7 +450,8 @@ func _command_damage_meters(player: Player, _args: Array):
 
 		var tower_name: String = tower.get_display_name()
 		var damage: float = tower.get_total_damage()
-		var damage_string: String = TowerDetails.int_format(damage)
+		# use roundi to display the same value as tower details
+		var damage_string: String = TowerDetails.int_format(roundi(damage))
 		
 		var damage_attack: float = tower.get_total_damage_by_type(Tower.DamageSource.Attack)
 		var attack_percentage: float = Utils.divide_safe(damage_attack, damage) * 100
@@ -460,7 +461,7 @@ func _command_damage_meters(player: Player, _args: Array):
 		var spell_percentage: float = Utils.divide_safe(damage_spell, damage) * 100
 		var spell_percentage_string: String = Utils.format_float(spell_percentage, 1)
 		
-		Messages.add_normal(player, "%s: [color=GOLD]%s[/color], attack:%s%%, spell: %s%%" % [tower_name, damage_string, attack_percentage_string, spell_percentage_string])
+		Messages.add_normal(player, "%s: [color=GOLD]%s[/color], attack: [color=GOLD]%s%%[/color], spell: [color=GOLD]%s%%[/color]" % [tower_name, damage_string, attack_percentage_string, spell_percentage_string])
 
 		count += 1
 
@@ -484,9 +485,9 @@ func _command_damage_meters_recent(player: Player, _args: Array):
 			break
 
 		var tower_name: String = tower.get_display_name()
-		
 		var damage: float = tower.get_total_damage_recent()
-		var damage_string: String = TowerDetails.int_format(damage)
+		# use roundi to display the same value as tower details
+		var damage_string: String = TowerDetails.int_format(roundi(damage))
 		
 		var damage_attack: float = tower.get_total_damage_recent(true, Tower.DamageSource.Attack)
 		var attack_percentage: float = Utils.divide_safe(damage_attack, damage) * 100
@@ -496,7 +497,7 @@ func _command_damage_meters_recent(player: Player, _args: Array):
 		var spell_percentage: float = Utils.divide_safe(damage_spell, damage) * 100
 		var spell_percentage_string: String = Utils.format_float(spell_percentage, 1)
 		
-		Messages.add_normal(player, "%s: [color=GOLD]%s[/color], attack:%s%%, spell: %s%%" % [tower_name, damage_string, attack_percentage_string, spell_percentage_string])
+		Messages.add_normal(player, "%s: [color=GOLD]%s[/color], attack: [color=GOLD]%s%%[/color], spell: [color=GOLD]%s%%[/color]" % [tower_name, damage_string, attack_percentage_string, spell_percentage_string])
 
 		count += 1
 

--- a/src/towers/tower.gd
+++ b/src/towers/tower.gd
@@ -161,6 +161,10 @@ func _ready():
 		_best_hit = _temp_preceding_tower._best_hit
 		_damage_dealt_total = _temp_preceding_tower._damage_dealt_total
 		_damage_dealt_to_wave_map = _temp_preceding_tower._damage_dealt_to_wave_map
+		_attack_damage_dealt = _temp_preceding_tower._attack_damage_dealt
+		_spell_damage_dealt = _temp_preceding_tower._spell_damage_dealt
+		_attack_damage_dealt_to_wave_map = _temp_preceding_tower._attack_damage_dealt_to_wave_map
+		_spell_damage_dealt_to_wave_map = _temp_preceding_tower._spell_damage_dealt_to_wave_map
 		
 #		Transition all buff groups from preceding tower
 		_buff_groups = _temp_preceding_tower._buff_groups.duplicate()
@@ -1127,16 +1131,29 @@ func get_dps_with_crit() -> float:
 # NOTE: getOverallDamage() in JASS, renamed to avoid confusion
 func get_total_damage() -> float:
 	return _damage_dealt_total
+	
+func get_total_damage_by_type(damage_source: DamageSource = DamageSource.Attack) -> float:
+	if damage_source == DamageSource.Attack:
+		return _attack_damage_dealt
+	if damage_source == DamageSource.Spell:
+		return _spell_damage_dealt
+	return 0.0
 
-# How much damage the tower dealt in total, during last 5 min
-func get_total_damage_recent() -> float:
+# How much damage the tower dealt in total, during last 5 waves
+func get_total_damage_recent(use_damage_source: bool = false, damage_source: DamageSource = DamageSource.Attack) -> float:
 	var total_damage_recent: float = 0
 	
 	var team: Team = _player.get_team()
 	var current_wave_level: int = team.get_level()
 	
+	var damage_dealt_to_wave_map: Dictionary = _damage_dealt_to_wave_map
+	if use_damage_source and damage_source == DamageSource.Attack:
+		damage_dealt_to_wave_map = _attack_damage_dealt_to_wave_map
+	if use_damage_source and damage_source == DamageSource.Spell:
+		damage_dealt_to_wave_map = _spell_damage_dealt_to_wave_map
+		
 	for i in range(current_wave_level, current_wave_level - 5, -1):
-		var damage_to_wave: float = _damage_dealt_to_wave_map.get(i, 0)
+		var damage_to_wave: float = damage_dealt_to_wave_map.get(i, 0)
 		total_damage_recent += damage_to_wave
 	
 	return total_damage_recent

--- a/src/unit/unit.gd
+++ b/src/unit/unit.gd
@@ -91,8 +91,12 @@ var _base_mana_regen: float = 0.0
 var _base_armor: float = 0.0
 var _kill_count: int = 0
 var _best_hit: float = 0.0
+var _attack_damage_dealt: float = 0.0
+var _spell_damage_dealt: float = 0.0
 var _damage_dealt_total: float = 0.0
 var _damage_dealt_to_wave_map: Dictionary = {}
+var _attack_damage_dealt_to_wave_map: Dictionary = {}
+var _spell_damage_dealt_to_wave_map: Dictionary = {}
 var _ethereal_count: int = 0
 var _silence_count: int = 0
 var _stun_count: int = 0
@@ -941,8 +945,19 @@ func _do_damage(target: Unit, damage_base: float, crit_ratio: float, damage_sour
 	
 	if !_damage_dealt_to_wave_map.has(wave_level):
 		_damage_dealt_to_wave_map[wave_level] = 0
-	
+	if !_attack_damage_dealt_to_wave_map.has(wave_level):
+		_attack_damage_dealt_to_wave_map[wave_level] = 0
+	if !_spell_damage_dealt_to_wave_map.has(wave_level):
+		_spell_damage_dealt_to_wave_map[wave_level] = 0
+		
 	_damage_dealt_to_wave_map[wave_level] += damage
+	
+	if damage_source == DamageSource.Spell:
+		_spell_damage_dealt += damage
+		_spell_damage_dealt_to_wave_map[wave_level] += damage
+	if damage_source == DamageSource.Attack:
+		_attack_damage_dealt += damage
+		_attack_damage_dealt_to_wave_map[wave_level] += damage
 
 	if damage > _best_hit:
 		_best_hit = damage

--- a/src/unit/unit.gd
+++ b/src/unit/unit.gd
@@ -943,19 +943,28 @@ func _do_damage(target: Unit, damage_base: float, crit_ratio: float, damage_sour
 	
 	var wave_level: int = target.get_spawn_level()
 	
+	# initialize all maps at once on first damage instance to wave_level
 	if !_damage_dealt_to_wave_map.has(wave_level):
 		_damage_dealt_to_wave_map[wave_level] = 0
-	if !_attack_damage_dealt_to_wave_map.has(wave_level):
-		_attack_damage_dealt_to_wave_map[wave_level] = 0
-	if !_spell_damage_dealt_to_wave_map.has(wave_level):
 		_spell_damage_dealt_to_wave_map[wave_level] = 0
+		_attack_damage_dealt_to_wave_map[wave_level] = 0
+		
 		
 	_damage_dealt_to_wave_map[wave_level] += damage
 	
 	if damage_source == DamageSource.Spell:
+		# re-init as safety fallback
+		if !_spell_damage_dealt_to_wave_map.has(wave_level):
+			_spell_damage_dealt_to_wave_map[wave_level] = 0
+		
 		_spell_damage_dealt += damage
 		_spell_damage_dealt_to_wave_map[wave_level] += damage
+		
 	if damage_source == DamageSource.Attack:
+		# re-init as safety fallback
+		if !_attack_damage_dealt_to_wave_map.has(wave_level):
+			_attack_damage_dealt_to_wave_map[wave_level] = 0
+			
 		_attack_damage_dealt += damage
 		_attack_damage_dealt_to_wave_map[wave_level] += damage
 


### PR DESCRIPTION
Type: UX/UI

What:
Chat commands: damage meters and damage meters recent show percentage contribution of attack and spell damage towards total damage dealt by tower. Internally, adds tracking of attack and spell damage dealt by towers.

Why:
I found it useful for power estimation of the carry towers damage composition to judge whether I’ll be able to beat high armor or immune creeps.

Impact expectations:
✅ No mechanical deviation from the original game. 
⚠️Slight performance hit due to tracking multiple types of damage on every damage instance - probably not noticeable.
✅ Used and liked by the playerbase. 

Status:
✅ Works	
✅ Code final pass / polish
✅ Playtest: short manual test of commands, tracking and upgrading tower (only Random with upgrade mode).

Example:
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/9e15a8fb-c7f3-445c-80fa-b530409bdbda" />


