### PR TITLE
Fix experience popup and combat log to show actual experience change

### DIFF
--- a/src/unit/unit.gd
+++ b/src/unit/unit.gd
@@ -736,6 +736,9 @@ func _change_experience(amount: float) -> float:
 	var actual_change_centi: int = new_exp_centi - old_exp_centi
 	var actual_change: float = actual_change_centi / 100.0
 
+	if actual_change_centi == 0:
+		return actual_change
+
 	var old_level: int = _level
 	var new_exp_float: float = new_exp_centi / 100.0
 	var new_level: int = Experience.get_level_at_exp(new_exp_float, get_player())
@@ -758,14 +761,14 @@ func _change_experience(amount: float) -> float:
 		EventBus.unit_leveled_up.emit()
 
 	var sign_string: String
-	if amount >= 0:
+	if actual_change >= 0:
 		sign_string = "+"
 	else:
 		sign_string = "-"
-	var number_string: String = String.num(abs(amount), 1)
+	var number_string: String = String.num(abs(actual_change), 1)
 	var exp_text: String = "%s%s exp" % [sign_string, number_string]
 	var text_color: Color
-	if amount >= 0:
+	if actual_change >= 0:
 		text_color = Color.LIME_GREEN
 	else:
 		text_color = Color.RED
@@ -785,7 +788,7 @@ func _change_experience(amount: float) -> float:
 
 		SFX.sfx_at_unit(SfxPaths.LEVEL_UP, self)
 
-	CombatLog.log_experience(self, amount)
+	CombatLog.log_experience(self, actual_change)
 
 	return actual_change
 


### PR DESCRIPTION
## Summary

When `_change_experience(amount)` is clamped by the unit's real experience, the function may currently display and log the requested amount instead of the actual applied change.

This is confusing in cases such as trying to remove 30 exp from a tower that has less than 30 exp:
- before: floating text / log still show `-30 exp`
- after: floating text / log show the actual transferred amount

This PR makes the experience popup and combat log use `actual_change` instead of the requested `amount`.

## Changes

- use `actual_change` for experience floating text
- use `actual_change` for combat log output
- return early when the rounded centi-exp change is `0`, so no misleading popup/log is shown when nothing actually changes

## Notes

- This PR intentionally includes only the code change in `src/unit/unit.gd`
- It does **not** include `assets/texts/texts.csv`
- Per `.github/TRANSLATING.md`, `texts.csv` is not tracked on GitHub, so any translation text adjustment should be attached separately if needed

## Suggested translation update

For consistency with the actual behavior, I also suggest updating the item description text separately in `texts.csv`:

- English:
  - `Transfers a flat 30 experience from this tower to another one.`
  - `Transfers up to 30 experience from this tower to another one.`

- Chinese:
  - `将本防御塔的30点经验值转移至另一防御塔。`
  - `将本防御塔至多30点经验值转移至另一防御塔。`

This wording change is not included in this PR because `texts.csv` is not part of the GitHub-tracked repository.

## Testing

Manual reasoning / code inspection only.

Suggested repro:
1. Try to transfer 30 exp from a tower with less than 30 exp
2. Observe that the popup and combat log should now show the actual removed amount instead of `30`
3. Try a case where rounded actual change is `0`
4. Observe that no misleading experience popup/log is shown

## AI-assisted note

This change and this PR text were prepared with AI assistance. The final diff was reviewed manually, and I take responsibility for the submitted changes.