### PR TITLE
fix instant desync for LAN 3+ players

### DIFF
--- a/src/actions/action_build_tower.gd
+++ b/src/actions/action_build_tower.gd
@@ -35,6 +35,8 @@ static func execute(action: Dictionary, player: Player, build_space: BuildSpace)
 
 	var new_tower: Tower = Tower.make(tower_id, player)
 
+	print_verbose("[desync-debug] built tower id=%d uid=%d (Unit._uid_max now %d)" % [tower_id, new_tower.get_uid(), Unit._uid_max])
+
 #	NOTE: need to add tile height to position because towers
 #	are built at ground floor
 	var build_position_canvas: Vector2 = VectorUtils.snap_canvas_pos_to_buildable_pos(mouse_pos)

--- a/src/game_scene/game_scene.gd
+++ b/src/game_scene/game_scene.gd
@@ -100,8 +100,11 @@ func _ready():
 # 	Save the seed which host gave to this client so that rng
 # 	on this game client is the same as on all other clients.
 	Globals.synced_rng.set_seed(origin_seed)
-	
+
 	print_verbose("Origin seed to: ", origin_seed)
+
+#	NOTE: ensure object UID counters are statically reset between sessions
+	_reset_uid_counters()
 
 	_setup_players()
 	PlayerManager.send_players_created_signal()
@@ -280,16 +283,23 @@ func _save_player_exp_on_quit():
 	local_team.convert_local_player_score_to_exp()
 
 
-func _setup_players():
-	var peer_id_list: Array[int] = []
-	var local_peer_id: int = multiplayer.get_unique_id()
-	peer_id_list.append(local_peer_id)
-	var remote_peer_id_list: PackedInt32Array = multiplayer.get_peers()
-	for peer_id in remote_peer_id_list:
-		peer_id_list.append(peer_id)
+func _reset_uid_counters():
+	Unit._uid_max = 1
+	Item._uid_max = 1
+	Autocast._uid_max = 1
+	ItemContainer._uid_max = 1
+	Projectile._uid_max = 1
+	ManualTimer._uid_max = 1
 
-#	NOTE: create players in the order of peer id's to ensure determinism
-	peer_id_list.sort()
+
+func _setup_players():
+#	NOTE: use the authoritative peer list provided by the host
+#	instead of multiplayer.get_peers().
+#	 See Globals._game_peer_id_list.
+	var peer_id_list: Array[int] = []
+	peer_id_list.assign(Globals.get_game_peer_id_list())
+
+	print_verbose("[desync-debug] _setup_players peer_id_list=%s (local peer %d)" % [str(peer_id_list), multiplayer.get_unique_id()])
 	
 #	Create teams
 	var team_mode: TeamMode.enm = Globals.get_team_mode()

--- a/src/singletons/globals.gd
+++ b/src/singletons/globals.gd
@@ -18,6 +18,10 @@ var _game_mode: GameMode.enm = GameMode.enm.BUILD
 var _difficulty: Difficulty.enm = Difficulty.enm.EASY
 var _team_mode: TeamMode.enm = TeamMode.enm.ONE_PLAYER_PER_TEAM
 var _origin_seed: int = 0
+# NOTE: authoritative, host-provided list of peer id's for the
+# current game. Used instead of multiplayer.get_peers() when
+# setting up players
+var _game_peer_id_list: Array = []
 var _update_ticks_per_physics_tick: int = 1
 var _connection_type: ConnectionType = ConnectionType.ENET
 var _enet_peer_id_to_player_name: Dictionary = {}
@@ -76,6 +80,10 @@ func get_origin_seed() -> int:
 	return _origin_seed
 
 
+func get_game_peer_id_list() -> Array:
+	return _game_peer_id_list
+
+
 func game_mode_is_random() -> bool:
 	return Globals.get_game_mode() == GameMode.enm.RANDOM_WITH_UPGRADES || Globals.get_game_mode() == GameMode.enm.TOTALLY_RANDOM
 
@@ -120,4 +128,3 @@ func get_title_screen_notification_list() -> Array[String]:
 
 func clear_title_screen_notification_list():
 	_title_screen_notification_list.clear()
-

--- a/src/ui/title_screen/lan_match/setup_lan_game.gd
+++ b/src/ui/title_screen/lan_match/setup_lan_game.gd
@@ -198,8 +198,14 @@ func _on_lan_lobby_menu_start_pressed():
 	var game_mode: GameMode.enm = _current_match_config.get_game_mode()
 	var team_mode: TeamMode.enm = _current_match_config.get_team_mode()
 	var origin_seed: int = randi()
-	
-	_title_screen.start_game.rpc(PlayerMode.enm.MULTIPLAYER, game_length, game_mode, difficulty, team_mode, origin_seed, Globals.ConnectionType.ENET)
+
+#	NOTE: build the authoritative peer list on the host (peer
+#	1) and pass it to all clients.
+	var peer_id_list: Array = [1]
+	peer_id_list.append_array(multiplayer.get_peers())
+	peer_id_list.sort()
+
+	_title_screen.start_game.rpc(PlayerMode.enm.MULTIPLAYER, game_length, game_mode, difficulty, team_mode, origin_seed, Globals.ConnectionType.ENET, peer_id_list)
 
 
 func _on_lan_connect_menu_join_pressed():

--- a/src/ui/title_screen/online/setup_online_game.gd
+++ b/src/ui/title_screen/online/setup_online_game.gd
@@ -400,7 +400,15 @@ func _on_peer_connected(_peer_id: int):
 		var team_mode: TeamMode.enm = _current_match_config.get_team_mode()
 		var origin_seed: int = randi()
 
-		_title_screen.start_game.rpc(PlayerMode.enm.MULTIPLAYER, game_length, game_mode, difficulty, team_mode, origin_seed, Globals.ConnectionType.NAKAMA)
+#		NOTE: build the authoritative peer list on the host
+#		(peer 1) and pass it to all clients, so every client
+#		sets up an identical player roster regardless of
+#		peer-discovery timing. See Globals._game_peer_id_list.
+		peer_id_list = [1]
+		peer_id_list.append_array(multiplayer.get_peers())
+		peer_id_list.sort()
+
+		_title_screen.start_game.rpc(PlayerMode.enm.MULTIPLAYER, game_length, game_mode, difficulty, team_mode, origin_seed, Globals.ConnectionType.NAKAMA, peer_id_list)
 
 
 func _on_host_created_game_match(game_match_id: String):

--- a/src/ui/title_screen/title_screen.gd
+++ b/src/ui/title_screen/title_screen.gd
@@ -62,7 +62,7 @@ func switch_to_tab(tab: TitleScreen.Tab):
 
 # NOTE: this function transitions the game from title screen to game scene. Can be called either by client itself or the host if the game is in multiplayer mode.
 @rpc("any_peer", "call_local", "reliable")
-func start_game(player_mode: PlayerMode.enm, wave_count: int, game_mode: GameMode.enm, difficulty: Difficulty.enm, team_mode: TeamMode.enm, origin_seed: int, connection_type: Globals.ConnectionType):
+func start_game(player_mode: PlayerMode.enm, wave_count: int, game_mode: GameMode.enm, difficulty: Difficulty.enm, team_mode: TeamMode.enm, origin_seed: int, connection_type: Globals.ConnectionType, peer_id_list: Array):
 #	NOTE: save game settings into globals so that GameScene
 #	can access them
 	Globals._player_mode = player_mode
@@ -72,6 +72,9 @@ func start_game(player_mode: PlayerMode.enm, wave_count: int, game_mode: GameMod
 	Globals._team_mode = team_mode
 	Globals._origin_seed = origin_seed
 	Globals._connection_type = connection_type
+#	NOTE: store the host-provided authoritative peer list so
+#	that all clients set up the same player roster.
+	Globals._game_peer_id_list = peer_id_list
 	
 #	NOTE: need to add a delay so that the game properly
 #	switches to displaying LOADING tab before starting
@@ -115,8 +118,10 @@ func _on_configure_singleplayer_menu_start_button_pressed():
 	Settings.set_setting(Settings.CACHED_GAME_MODE, game_mode_string)
 	Settings.set_setting(Settings.CACHED_GAME_LENGTH, game_length)
 	Settings.flush()
-	
-	start_game(PlayerMode.enm.SINGLEPLAYER, game_length, game_mode, difficulty, team_mode, origin_seed, Globals.ConnectionType.ENET)
+
+	var peer_id_list: Array = [multiplayer.get_unique_id()]
+
+	start_game(PlayerMode.enm.SINGLEPLAYER, game_length, game_mode, difficulty, team_mode, origin_seed, Globals.ConnectionType.ENET, peer_id_list)
 
 
 func _on_generic_tab_cancel_pressed():


### PR DESCRIPTION
While not reproducible purely locally, LAN games across different machines with 3+ players were instantly desyncing on the first tower build.  In testing, it appeared that the uids for built towers differed between clients, because all clients had a tower visible on their screen but the action initiator often had no game state record of their tower matching the UIDs being checked by the host. The action clearly got processed, but the identifying details must have differed. Thus,

1. ensure that all uids are set to 1 during game setup
2. push a sorted peer list to clients from the host instead of relying on each client discovering peers and sorting independently

Tested on windows and linux builds in lan games with 3+ players (& single player).  With these small changes we got a 6-player lobby to wave 150 without desyncs (although we did all lose at that point :)) Not sure yet if this fix also helps at all with any non-lan, nakama-based sessions with 3+ players