### PR TITLE
LAN multiplayer enhancements

### DIFF
--- a/src/game_scene/game_client.gd
+++ b/src/game_scene/game_client.gd
@@ -159,6 +159,10 @@ func receive_pong():
 	_game_host.receive_ping_time_for_player.rpc_id(1, ping_time)
 
 
+@rpc("authority", "call_local", "reliable")
+func set_enet_player_names(player_name_map: Dictionary):
+	Globals._enet_peer_id_to_player_name = player_name_map
+
 # NOTE: arg must be Array instead of Array[String]. RPC
 # calls have typing issues
 @rpc("authority", "call_local", "reliable")
@@ -167,7 +171,6 @@ func set_lagging_players(lagging_player_list: Array):
 
 	_hud.set_waiting_for_lagging_players_indicator_player_list(lagging_player_list)
 	_hud.set_waiting_for_lagging_players_indicator_visible(players_are_lagging)
-
 
 # Receive desync notification from server and send back stored checksum data
 @rpc("authority", "call_local", "reliable")
@@ -180,6 +183,12 @@ func receive_desync_notification(tick: int):
 	else:
 		push_error("  ERROR: No stored checksum data for tick %d" % tick)
 
+# notification from the authority to drop a given player.  Typically a result of lagging players,
+# but the lagging players list will be reset *separately* once the host recovers from the wait loop 
+@rpc("authority", "call_local", "reliable")
+func receive_drop_player_notification(id: int):
+	push_warning("dropping player by id %s" % id)
+	PlayerManager.drop_player(id)
 
 #########################
 ###      Private      ###

--- a/src/game_scene/game_host.gd
+++ b/src/game_scene/game_host.gd
@@ -190,9 +190,9 @@ func receive_checksum_data_from_client(tick: int, checksum_data: Dictionary):
 
 	_checksum_data_map[tick][player_id] = checksum_data
 
-	var player_list: Array[Player] = PlayerManager.get_player_list()
-	var player_count: int = player_list.size()
-	var collected_all_data: bool = _checksum_data_map[tick].size() == player_count
+	var player_list: Array[Player] = PlayerManager.get_undropped_player_list()
+	var collected_all_data: bool = \
+		player_list.all(func(p): return _checksum_data_map[tick].has(p.get_id()))
 
 	if collected_all_data:
 		_log_detailed_desync_data(tick)

--- a/src/game_scene/game_host.gd
+++ b/src/game_scene/game_host.gd
@@ -80,6 +80,8 @@ func _ready():
 	if !multiplayer.is_server():
 		return
 
+	EventBus.host_requested_drop_lagging_players.connect(_on_host_requested_drop_lagging_players)
+
 	PlayerManager.players_created.connect(_on_players_created)
 	
 	_turn_length = Utils.get_turn_length()
@@ -133,17 +135,18 @@ func receive_action(action: Dictionary):
 @rpc("any_peer", "call_local", "reliable")
 func receive_timeslot_checksum(tick: int, checksum: PackedByteArray):
 	var peer_id: int = multiplayer.get_remote_sender_id()
-	var player: Player = PlayerManager.get_player_by_peer_id(peer_id)
-	var player_id: int = player.get_id()
+	var this_player: Player = PlayerManager.get_player_by_peer_id(peer_id)
+	var this_player_id: int = this_player.get_id()
 
 	if !_checksum_map.has(tick):
 		_checksum_map[tick] = {}
 
-	_checksum_map[tick][player_id] = checksum
+	_checksum_map[tick][this_player_id] = checksum
 
-	var player_list: Array[Player] = PlayerManager.get_player_list()
-	var player_count: int = player_list.size()
-	var collected_all_checksums_for_tick: bool = _checksum_map[tick].size() == player_count
+	var player_list: Array[Player] = PlayerManager.get_undropped_player_list()
+
+	var collected_all_checksums_for_tick: bool = \
+		player_list.all(func(p): return _checksum_map[tick].has(p.get_id()))
 
 	if collected_all_checksums_for_tick:
 		_verify_checksums(tick)
@@ -230,7 +233,7 @@ func _update_state_running():
 		_current_tick += 1
 
 #	Send timeslots
-	var player_list: Array[Player] = PlayerManager.get_player_list()
+	var player_list: Array[Player] = PlayerManager.get_undropped_player_list()
 
 	for player in player_list:
 		var player_id: int = player.get_id()
@@ -261,7 +264,7 @@ func _save_timeslot():
 func _get_highest_ping() -> int:
 	var highest_ping: int = 0
 
-	var player_list: Array[Player] = PlayerManager.get_player_list()
+	var player_list: Array[Player] = PlayerManager.get_undropped_player_list()
 
 	for player in player_list:
 		var player_id: int = player.get_id()
@@ -284,7 +287,7 @@ func _get_lagging_players() -> Array[Player]:
 	if player_mode == PlayerMode.enm.SINGLEPLAYER:
 		return lagging_player_list
 
-	var player_list: Array[Player] = PlayerManager.get_player_list()
+	var player_list: Array[Player] = PlayerManager.get_undropped_player_list()
 
 	var ticks_msec: int = Time.get_ticks_msec()
 
@@ -311,7 +314,7 @@ func _verify_checksums(tick: int):
 
 	var authority_checksum: PackedByteArray = player_to_checksum[authority_player_id]
 
-	var player_list: Array[Player] = PlayerManager.get_player_list()
+	var player_list: Array[Player] = PlayerManager.get_undropped_player_list()
 
 	var desynced_players: Array[String] = []
 
@@ -351,7 +354,7 @@ func _log_desync_detected(tick: int, authority_player: Player, desynced_players:
 	var authority_checksum_hex: String = authority_checksum.hex_encode()
 	push_error("  Authority checksum: %s" % authority_checksum_hex)
 
-	var player_list: Array[Player] = PlayerManager.get_player_list()
+	var player_list: Array[Player] = PlayerManager.get_undropped_player_list()
 	for player in player_list:
 		var player_id: int = player.get_id()
 		if player_id == authority_player_id:
@@ -393,7 +396,7 @@ func _log_detailed_desync_data(tick: int):
 	log_lines.append("DETAILED DESYNC DATA COMPARISON - tick %d" % tick)
 	log_lines.append("========================================")
 
-	var player_list: Array[Player] = PlayerManager.get_player_list()
+	var player_list: Array[Player] = PlayerManager.get_undropped_player_list()
 	var authority_player: Player = PlayerManager.get_player_by_peer_id(1)
 	var authority_player_id: int = authority_player.get_id()
 
@@ -711,3 +714,23 @@ func _on_alive_check_timer_timeout():
 
 	var lagging_player_name_list: Array[String] = _get_player_name_list(lagging_players)
 	_game_client.set_lagging_players.rpc(lagging_player_name_list)
+
+func _on_host_requested_drop_lagging_players():
+	if !multiplayer.is_server():
+		return
+	if _state != HostState.WAITING_FOR_LAGGING_PLAYERS:
+		return
+	var lagging_players: Array[Player] = _get_lagging_players()
+	var players_are_lagging: bool = lagging_players.size() > 0
+	if players_are_lagging:
+		# -- enet handling --
+		# todo: handle non-enet also
+		for player in PlayerManager.get_undropped_player_list():
+			var peer_id = player.get_peer_id()
+			for to_drop in lagging_players:
+				Globals._enet_peer_id_to_player_name[to_drop.get_peer_id()] = "<DISCONNECTED>"
+				_game_client.receive_drop_player_notification.rpc_id(peer_id, to_drop.get_id())
+			_game_client.set_enet_player_names.rpc_id(peer_id, Globals._enet_peer_id_to_player_name)
+			_game_client.set_lagging_players.rpc_id(peer_id, [])
+	else:
+		return

--- a/src/game_scene/game_scene.gd
+++ b/src/game_scene/game_scene.gd
@@ -892,7 +892,6 @@ func _on_game_menu_quit_pressed():
 func _on_player_requested_quit_to_title():
 	_quit_to_title()
 
-
 func _quit_to_title():
 	_save_player_exp_on_quit()
 	_cleanup_all_objects()
@@ -903,7 +902,6 @@ func _quit_to_title():
 #	4.1->4.3 migration, for unknown reason.
 	var title_screen_scene: PackedScene = load("res://src/ui/title_screen/title_screen.tscn")
 	get_tree().change_scene_to_packed(title_screen_scene)
-
 
 func _on_tutorial_controller_tutorial_triggered(tutorial_id):
 #	NOTE: ignore tutorial triggers in build mode because

--- a/src/game_scene/game_scene.tscn
+++ b/src/game_scene/game_scene.tscn
@@ -436,9 +436,6 @@ process_mode = 1
 size_flags_horizontal = 1
 mouse_filter = 2
 
-[node name="DropPlayersButton" parent="UI/HUD/PlayersAreLaggingIndicator/PanelContainer/VBoxContainer" index="2"]
-text = "Drop Lagging Players"
-
 [node name="ShadowBelowBuilderMenu" type="ColorRect" parent="UI"]
 visible = false
 anchors_preset = 15
@@ -514,5 +511,3 @@ layout_mode = 2
 [connection signal="continue_pressed" from="UI/GameMenu" to="." method="_on_game_menu_continue_pressed"]
 [connection signal="quit_pressed" from="UI/GameMenu" to="." method="_on_game_menu_quit_pressed"]
 [connection signal="hidden" from="UI/VBoxContainer/TutorialMenu" to="." method="_on_tutorial_menu_hidden"]
-
-[editable path="UI/HUD"]

--- a/src/game_scene/game_scene.tscn
+++ b/src/game_scene/game_scene.tscn
@@ -436,6 +436,9 @@ process_mode = 1
 size_flags_horizontal = 1
 mouse_filter = 2
 
+[node name="DropPlayersButton" parent="UI/HUD/PlayersAreLaggingIndicator/PanelContainer/VBoxContainer" index="2"]
+text = "Drop Lagging Players"
+
 [node name="ShadowBelowBuilderMenu" type="ColorRect" parent="UI"]
 visible = false
 anchors_preset = 15
@@ -511,3 +514,5 @@ layout_mode = 2
 [connection signal="continue_pressed" from="UI/GameMenu" to="." method="_on_game_menu_continue_pressed"]
 [connection signal="quit_pressed" from="UI/GameMenu" to="." method="_on_game_menu_quit_pressed"]
 [connection signal="hidden" from="UI/VBoxContainer/TutorialMenu" to="." method="_on_tutorial_menu_hidden"]
+
+[editable path="UI/HUD"]

--- a/src/player/player.gd
+++ b/src/player/player.gd
@@ -72,6 +72,7 @@ var _player_name: String = "Player"
 var _chat_ignored: bool = false
 var _attack_range_bonus: float = 0.0
 var _tower_exp_bonus: float = 0.0
+var _is_dropped: bool = false
 
 @export var _item_stash: ItemContainer
 @export var _horadric_stash: ItemContainer
@@ -188,6 +189,8 @@ func generate_waves():
 
 
 func start_wave(level: int):
+	if (_is_dropped):
+		return
 	_wave_spawner.start_wave(level)
 
 
@@ -211,11 +214,11 @@ func wave_is_in_progress() -> bool:
 
 
 func current_wave_is_finished() -> bool:
-	return _wave_spawner.current_wave_is_finished()
+	return _is_dropped || _wave_spawner.current_wave_is_finished()
 
 
 func wave_is_finished(level: int) -> bool:
-	return _wave_spawner.wave_is_finished(level)
+	return _is_dropped || _wave_spawner.wave_is_finished(level)
 
 
 func set_builder(builder_id: int):
@@ -746,6 +749,10 @@ func _determine_player_name() -> String:
 
 	return player_name
 
+func drop():
+	_is_dropped = true
+	_team.remove_player(self)
+	_player_name = "<DISCONNECTED>"
 
 #########################
 ###     Callbacks     ###

--- a/src/player/team.gd
+++ b/src/player/team.gd
@@ -79,6 +79,14 @@ func add_player(player: Player):
 	player.wave_spawned.connect(_on_player_wave_spawned)
 	player.wave_finished.connect(_on_player_wave_finished)
 
+func remove_player(player: Player):
+	var found_player_index = -1
+	for i in _player_list.size():
+		if _player_list[i].get_id() == player.get_id():
+			found_player_index = i
+
+	if (found_player_index != -1):
+		_player_list.remove_at(found_player_index)
 
 func get_id() -> int:
 	return _id
@@ -397,7 +405,6 @@ func _on_player_wave_finished(level: int):
 #	level, then we shouldn't start next wave timer.
 	if finished_current_level && need_to_start_next_wave_timer && can_start_next_wave_timer:
 		_start_timer_before_next_wave(Constants.TIME_BETWEEN_WAVES)
-
 
 #########################
 ###       Static      ###

--- a/src/singletons/event_bus.gd
+++ b/src/singletons/event_bus.gd
@@ -34,6 +34,7 @@ signal player_stopped_build_process()
 signal mouse_entered_unit(unit: Unit)
 signal mouse_exited_unit(unit: Unit)
 signal item_started_flying_to_item_stash(item: Item, canvas_pos: Vector2)
+signal host_requested_drop_lagging_players()
 
 # NOTE: signals for triggering tutorials
 signal finished_tutorial_section(tutorial_id: int)

--- a/src/singletons/player_manager.gd
+++ b/src/singletons/player_manager.gd
@@ -5,6 +5,7 @@ extends Node
 
 
 signal players_created()
+signal player_dropped(int)
 
 
 var _id_to_player_map: Dictionary = {}
@@ -65,6 +66,8 @@ func get_player_by_nakama_user_id(user_id: String) -> Player:
 func get_player_list() -> Array[Player]:
 	return _player_list.duplicate()
 
+func get_undropped_player_list() -> Array[Player]:
+	return _player_list.filter(func(p): return !p._is_dropped)
 
 func reset():
 	_id_to_player_map = {}
@@ -89,6 +92,11 @@ func add_player(player: Player):
 			return a.get_id() < b.get_id()
 			)
 
+func drop_player(id: int):
+	var maybePlayer: Array[Player] = _player_list.filter(func(p): return p.get_id() == id)
+	if maybePlayer.size() != 0:
+		print_verbose("found a player to drop: id=%s name=%s builder=%s" % [id, maybePlayer.front().get_player_name(), maybePlayer.front().get_builder()])
+		maybePlayer.front().drop()
 
 func send_players_created_signal():
 	players_created.emit()

--- a/src/ui/hud/hud.gd
+++ b/src/ui/hud/hud.gd
@@ -20,6 +20,8 @@ class_name HUD extends Control
 @export var _ping_label: Label
 @export var _players_are_lagging_indicator: MarginContainer
 @export var _lagging_player_list_label: Label
+@onready var _quit_button: Button = $PlayersAreLaggingIndicator/PanelContainer/VBoxContainer/QuitButton
+@onready var _drop_players_button: Button = $PlayersAreLaggingIndicator/PanelContainer/VBoxContainer/DropPlayersButton
 @export var _multiplayer_pause_indicator: Control
 @export var _mission_tracker_container: MissionTrackerContainer
 @export var _one_time_help_popup: OneTimeHelpPopup
@@ -60,7 +62,11 @@ func toggle_ping_indicator_visibility():
 
 func set_waiting_for_lagging_players_indicator_visible(indicator_visible: bool):
 	_players_are_lagging_indicator.visible = indicator_visible
+	var is_host = multiplayer.is_server()
+	_quit_button.visible = indicator_visible
 
+	if (is_host):
+		_drop_players_button.visible = indicator_visible
 
 func set_waiting_for_lagging_players_indicator_player_list(lagging_player_list: Array):
 	var lagging_player_list_text: String = ""
@@ -235,6 +241,8 @@ func _on_local_game_lose():
 func _on_quit_button_pressed():
 	EventBus.player_requested_quit_to_title.emit()
 
+func _on_drop_lagging_button_pressed():
+	EventBus.host_requested_drop_lagging_players.emit()
 
 func _on_one_time_help_popup_close_pressed() -> void:
 	_one_time_help_popup.visible = false

--- a/src/ui/hud/hud.gd
+++ b/src/ui/hud/hud.gd
@@ -20,8 +20,8 @@ class_name HUD extends Control
 @export var _ping_label: Label
 @export var _players_are_lagging_indicator: MarginContainer
 @export var _lagging_player_list_label: Label
-@onready var _quit_button: Button = $PlayersAreLaggingIndicator/PanelContainer/VBoxContainer/QuitButton
-@onready var _drop_players_button: Button = $PlayersAreLaggingIndicator/PanelContainer/VBoxContainer/DropPlayersButton
+@export var _quit_button: Button
+@export var _drop_players_button: Button
 @export var _multiplayer_pause_indicator: Control
 @export var _mission_tracker_container: MissionTrackerContainer
 @export var _one_time_help_popup: OneTimeHelpPopup

--- a/src/ui/hud/hud.tscn
+++ b/src/ui/hud/hud.tscn
@@ -464,7 +464,7 @@ text = "Quit to Title"
 [node name="DropPlayersButton" type="Button" parent="PlayersAreLaggingIndicator/PanelContainer/VBoxContainer"]
 visible = false
 layout_mode = 2
-text = "Quit to Title"
+text = "Drop Lagging Players"
 
 [node name="MultiplayerPauseIndicator" parent="." instance=ExtResource("20_cbamn")]
 visible = false

--- a/src/ui/hud/hud.tscn
+++ b/src/ui/hud/hud.tscn
@@ -426,6 +426,7 @@ grow_horizontal = 0
 grow_vertical = 0
 
 [node name="PlayersAreLaggingIndicator" type="MarginContainer" parent="."]
+visible = false
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0

--- a/src/ui/hud/hud.tscn
+++ b/src/ui/hud/hud.tscn
@@ -424,7 +424,6 @@ grow_horizontal = 0
 grow_vertical = 0
 
 [node name="PlayersAreLaggingIndicator" type="MarginContainer" parent="."]
-visible = false
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -458,6 +457,12 @@ Alice"
 horizontal_alignment = 1
 
 [node name="QuitButton" type="Button" parent="PlayersAreLaggingIndicator/PanelContainer/VBoxContainer"]
+visible = false
+layout_mode = 2
+text = "Quit to Title"
+
+[node name="DropPlayersButton" type="Button" parent="PlayersAreLaggingIndicator/PanelContainer/VBoxContainer"]
+visible = false
 layout_mode = 2
 text = "Quit to Title"
 
@@ -468,3 +473,4 @@ layout_mode = 1
 [connection signal="close_pressed" from="MarginContainer3/VBoxContainer/OneTimeHelpPopup" to="." method="_on_one_time_help_popup_close_pressed"]
 [connection signal="details_pressed" from="MarginContainer5/VBoxContainer2/UnitMenu" to="." method="_on_unit_menu_details_pressed"]
 [connection signal="pressed" from="PlayersAreLaggingIndicator/PanelContainer/VBoxContainer/QuitButton" to="." method="_on_quit_button_pressed"]
+[connection signal="pressed" from="PlayersAreLaggingIndicator/PanelContainer/VBoxContainer/DropPlayersButton" to="." method="_on_drop_lagging_button_pressed"]

--- a/src/ui/hud/hud.tscn
+++ b/src/ui/hud/hud.tscn
@@ -37,7 +37,7 @@ unicode = 105
 [sub_resource type="Shortcut" id="Shortcut_ree63"]
 events = [SubResource("InputEventKey_cgjl0")]
 
-[node name="HUD" type="Control" node_paths=PackedStringArray("_error_message_container", "_normal_message_container", "_game_over_label", "_elements_menu", "_tower_stash_menu", "_item_stash_menu", "_tower_stash_button", "_item_stash_button", "_top_left_menu", "_unit_menu", "_chat_line_edit", "_desync_indicator", "_button_tooltip_top", "_button_tooltip_bottom", "_tower_details", "_creep_details", "_ping_label", "_players_are_lagging_indicator", "_lagging_player_list_label", "_multiplayer_pause_indicator", "_mission_tracker_container", "_one_time_help_popup")]
+[node name="HUD" type="Control" node_paths=PackedStringArray("_error_message_container", "_normal_message_container", "_game_over_label", "_elements_menu", "_tower_stash_menu", "_item_stash_menu", "_tower_stash_button", "_item_stash_button", "_top_left_menu", "_unit_menu", "_chat_line_edit", "_desync_indicator", "_button_tooltip_top", "_button_tooltip_bottom", "_tower_details", "_creep_details", "_ping_label", "_players_are_lagging_indicator", "_lagging_player_list_label", "_quit_button", "_drop_players_button", "_multiplayer_pause_indicator", "_mission_tracker_container", "_one_time_help_popup")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -67,6 +67,8 @@ _creep_details = NodePath("MarginContainer4/CreepDetails")
 _ping_label = NodePath("MarginContainer10/VBoxContainer/PingLabel")
 _players_are_lagging_indicator = NodePath("PlayersAreLaggingIndicator")
 _lagging_player_list_label = NodePath("PlayersAreLaggingIndicator/PanelContainer/VBoxContainer/VBoxContainer2/LaggingPlayerListLabel")
+_quit_button = NodePath("PlayersAreLaggingIndicator/PanelContainer/VBoxContainer/QuitButton")
+_drop_players_button = NodePath("PlayersAreLaggingIndicator/PanelContainer/VBoxContainer/DropPlayersButton")
 _multiplayer_pause_indicator = NodePath("MultiplayerPauseIndicator")
 _mission_tracker_container = NodePath("MarginContainer3/VBoxContainer/MissionTrackerContainer")
 _one_time_help_popup = NodePath("MarginContainer3/VBoxContainer/OneTimeHelpPopup")

--- a/src/ui/title_screen/lan_match/setup_lan_game.gd
+++ b/src/ui/title_screen/lan_match/setup_lan_game.gd
@@ -44,6 +44,8 @@ func _update_player_list_in_lobby_menu():
 		var player_name: String = _peer_id_to_player_name_map.get(peer_id, fallback_string)
 		player_list.append(player_name)
 	
+	print_verbose("[player name debug] lobby has player list `%s`" % player_list)
+
 	_lan_lobby_menu.set_player_list(player_list)
 
 
@@ -53,6 +55,7 @@ func _update_player_list_in_lobby_menu():
 @rpc("any_peer", "call_local", "reliable")
 func _give_local_player_name_to_host(player_name: String):
 	var peer_id: int = multiplayer.get_remote_sender_id()
+	print_verbose("[player name debug] peer `%s` sending name `%s` to server" % [peer_id, player_name])
 	_peer_id_to_player_name_map[peer_id] = player_name
 
 	_receive_player_name_map_from_host.rpc(_peer_id_to_player_name_map)
@@ -61,7 +64,8 @@ func _give_local_player_name_to_host(player_name: String):
 @rpc("authority", "call_local", "reliable")
 func _receive_player_name_map_from_host(player_name_map: Dictionary):
 	_peer_id_to_player_name_map = player_name_map
-	
+
+	print_verbose("[player name debug] received nameMap `%s`" % player_name_map)
 #	NOTE: need to update displayed player list to show
 #	updated player names
 	_update_player_list_in_lobby_menu()
@@ -191,8 +195,8 @@ func _on_lan_lobby_menu_start_pressed():
 		
 		return
 	
-	Globals._enet_peer_id_to_player_name = _peer_id_to_player_name_map
-	
+	print_verbose("[player name debug] lan starting with this player name map `%s`" % _peer_id_to_player_name_map)
+
 	var difficulty: Difficulty.enm = _current_match_config.get_difficulty()
 	var game_length: int = _current_match_config.get_game_length()
 	var game_mode: GameMode.enm = _current_match_config.get_game_mode()
@@ -205,7 +209,7 @@ func _on_lan_lobby_menu_start_pressed():
 	peer_id_list.append_array(multiplayer.get_peers())
 	peer_id_list.sort()
 
-	_title_screen.start_game.rpc(PlayerMode.enm.MULTIPLAYER, game_length, game_mode, difficulty, team_mode, origin_seed, Globals.ConnectionType.ENET, peer_id_list)
+	_title_screen.start_game.rpc(PlayerMode.enm.MULTIPLAYER, game_length, game_mode, difficulty, team_mode, origin_seed, Globals.ConnectionType.ENET, peer_id_list, _peer_id_to_player_name_map)
 
 
 func _on_lan_connect_menu_join_pressed():

--- a/src/ui/title_screen/lan_match/setup_lan_game.gd
+++ b/src/ui/title_screen/lan_match/setup_lan_game.gd
@@ -43,8 +43,6 @@ func _update_player_list_in_lobby_menu():
 		var fallback_string: String = "Player %d" % peer_id
 		var player_name: String = _peer_id_to_player_name_map.get(peer_id, fallback_string)
 		player_list.append(player_name)
-	
-	print_verbose("[player name debug] lobby has player list `%s`" % player_list)
 
 	_lan_lobby_menu.set_player_list(player_list)
 
@@ -55,7 +53,6 @@ func _update_player_list_in_lobby_menu():
 @rpc("any_peer", "call_local", "reliable")
 func _give_local_player_name_to_host(player_name: String):
 	var peer_id: int = multiplayer.get_remote_sender_id()
-	print_verbose("[player name debug] peer `%s` sending name `%s` to server" % [peer_id, player_name])
 	_peer_id_to_player_name_map[peer_id] = player_name
 
 	_receive_player_name_map_from_host.rpc(_peer_id_to_player_name_map)
@@ -65,7 +62,6 @@ func _give_local_player_name_to_host(player_name: String):
 func _receive_player_name_map_from_host(player_name_map: Dictionary):
 	_peer_id_to_player_name_map = player_name_map
 
-	print_verbose("[player name debug] received nameMap `%s`" % player_name_map)
 #	NOTE: need to update displayed player list to show
 #	updated player names
 	_update_player_list_in_lobby_menu()
@@ -194,8 +190,6 @@ func _on_lan_lobby_menu_start_pressed():
 		Utils.show_popup_message(self, tr("GENERIC_ERROR_TITLE"), tr("SETUP_LAN_ERROR_ONLY_HOST_CAN_START"))
 		
 		return
-	
-	print_verbose("[player name debug] lan starting with this player name map `%s`" % _peer_id_to_player_name_map)
 
 	var difficulty: Difficulty.enm = _current_match_config.get_difficulty()
 	var game_length: int = _current_match_config.get_game_length()

--- a/src/ui/title_screen/online/setup_online_game.gd
+++ b/src/ui/title_screen/online/setup_online_game.gd
@@ -408,7 +408,7 @@ func _on_peer_connected(_peer_id: int):
 		peer_id_list.append_array(multiplayer.get_peers())
 		peer_id_list.sort()
 
-		_title_screen.start_game.rpc(PlayerMode.enm.MULTIPLAYER, game_length, game_mode, difficulty, team_mode, origin_seed, Globals.ConnectionType.NAKAMA, peer_id_list)
+		_title_screen.start_game.rpc(PlayerMode.enm.MULTIPLAYER, game_length, game_mode, difficulty, team_mode, origin_seed, Globals.ConnectionType.NAKAMA, peer_id_list, {})
 
 
 func _on_host_created_game_match(game_match_id: String):

--- a/src/ui/title_screen/title_screen.gd
+++ b/src/ui/title_screen/title_screen.gd
@@ -62,7 +62,7 @@ func switch_to_tab(tab: TitleScreen.Tab):
 
 # NOTE: this function transitions the game from title screen to game scene. Can be called either by client itself or the host if the game is in multiplayer mode.
 @rpc("any_peer", "call_local", "reliable")
-func start_game(player_mode: PlayerMode.enm, wave_count: int, game_mode: GameMode.enm, difficulty: Difficulty.enm, team_mode: TeamMode.enm, origin_seed: int, connection_type: Globals.ConnectionType, peer_id_list: Array):
+func start_game(player_mode: PlayerMode.enm, wave_count: int, game_mode: GameMode.enm, difficulty: Difficulty.enm, team_mode: TeamMode.enm, origin_seed: int, connection_type: Globals.ConnectionType, peer_id_list: Array, player_name_map: Dictionary):
 #	NOTE: save game settings into globals so that GameScene
 #	can access them
 	Globals._player_mode = player_mode
@@ -75,7 +75,7 @@ func start_game(player_mode: PlayerMode.enm, wave_count: int, game_mode: GameMod
 #	NOTE: store the host-provided authoritative peer list so
 #	that all clients set up the same player roster.
 	Globals._game_peer_id_list = peer_id_list
-	
+	Globals._enet_peer_id_to_player_name = player_name_map
 #	NOTE: need to add a delay so that the game properly
 #	switches to displaying LOADING tab before starting
 #	change_scene_to_packed()
@@ -121,7 +121,7 @@ func _on_configure_singleplayer_menu_start_button_pressed():
 
 	var peer_id_list: Array = [multiplayer.get_unique_id()]
 
-	start_game(PlayerMode.enm.SINGLEPLAYER, game_length, game_mode, difficulty, team_mode, origin_seed, Globals.ConnectionType.ENET, peer_id_list)
+	start_game(PlayerMode.enm.SINGLEPLAYER, game_length, game_mode, difficulty, team_mode, origin_seed, Globals.ConnectionType.ENET, peer_id_list, {})
 
 
 func _on_generic_tab_cancel_pressed():


### PR DESCRIPTION
- LAN multiplayer name fixes: names now appear correctly on the scoreboard and in the chat, for players besides the game host
- the game host can now choose to drop lagging players.  Dropped player's wave spawner is disabled, and their checksums are safely discounted for desync detection. Not currently deleting their towers but could be done if desired

tested on windows and linux, LAN and singleplayer only.  Not able to connect to nakama to test webrtc, so e.g. only messed with the enet names map