### PR TITLE
fix wheel of fortune raise chance text

### DIFF
--- a/src/items/item_behaviors/bloodthirsty_wheel_of_fortune.gd
+++ b/src/items/item_behaviors/bloodthirsty_wheel_of_fortune.gd
@@ -47,7 +47,7 @@ func on_kill(_event: Event):
 				
 				item.user_real = item.user_real + 0.04
 				t.modify_property(ModificationType.enm.MOD_ITEM_CHANCE_ON_KILL, 0.04)
-				var item_chance_raised_text: String = tr("GZ82")
+				var item_chance_raised_text: String = tr("YRQV")
 				t.get_player().display_small_floating_text(item_chance_raised_text, t, Color8(0, 0, 255), 30)
 
 


### PR DESCRIPTION
both "lowered" and "raised" text refered to the `GZ82` localization.  The correct value for raised is `YRQV`