### PR TITLE
use get_uid instead of get_instance_id where possible

### DIFF
--- a/src/items/item_behaviors/jah_rakals_fury.gd
+++ b/src/items/item_behaviors/jah_rakals_fury.gd
@@ -15,7 +15,7 @@ func item_init():
 
 
 func on_attack(event: Event):
-	if item.user_int == event.get_target().get_instance_id():
+	if item.user_int == event.get_target().get_uid():
 # 		100% attack speed limit
 		if item.user_real != 1.00 && item.user_real + 0.02 > 1.00:
 #			Add the remaining bonus (99% -> 101%; limit -> 100%; add 100% - 99% = 1%)
@@ -27,7 +27,7 @@ func on_attack(event: Event):
 			item.user_real = item.user_real + 0.02
 	else:
 #		Save current target
-		item.user_int = event.get_target().get_instance_id()
+		item.user_int = event.get_target().get_uid()
 #		Temp variable to store the current bonus
 		item.user_real2 = item.user_real
 #		Calculate the new bonus (Current bonus * (50% + towerlevel%))

--- a/src/items/item_behaviors/overcharge_shot.gd
+++ b/src/items/item_behaviors/overcharge_shot.gd
@@ -12,7 +12,7 @@ func load_triggers(triggers: BuffType):
 func overcharge_pt_on_collision(P: Projectile, U: Unit):
 	var T: Tower
 
-	if U.get_instance_id() != P.user_int:
+	if U.get_uid() != P.user_int:
 #		Not the original target
 		T = P.get_caster()
 		T.do_attack_damage(U, P.user_real, T.calc_attack_multicrit(0, 0, 0))
@@ -34,5 +34,5 @@ func on_damage(event: Event):
 		C = event.get_target()
 		angle = rad_to_deg(atan2(C.get_y() - T.get_y(), C.get_x() - T.get_x()))
 		P = Projectile.create_from_unit(overcharge_pt, T, C, angle, 1.0, 1.0)
-		P.user_int = C.get_instance_id()
+		P.user_int = C.get_uid()
 		P.user_real = T.get_current_attack_damage_with_bonus() * (0.35 + 0.006 * T.get_level())

--- a/src/towers/tower_behaviors/zealot.gd
+++ b/src/towers/tower_behaviors/zealot.gd
@@ -159,12 +159,12 @@ func on_damage(event: Event):
 		phase_wound = wound_bt.apply(tower, target, 1)
 #		stack counter
 		phase_wound.user_int = 1
-		phase_wound.user_int2 = tower.get_instance_id()
+		phase_wound.user_int2 = tower.get_uid()
 	else:
 #		multiple zealots + family member check. If another zealot attacks, no armor pierce for him
 #		only the guy who put the first wound gets armor pierce
 #		perfection would need hashtables storing wound level for every tower,creep pair. Not worth it i think.
-		if phase_wound.user_int2 != tower.get_instance_id():
+		if phase_wound.user_int2 != tower.get_uid():
 			return
 
 		phase_wound.user_int = min(5, phase_wound.user_int + 1)


### PR DESCRIPTION
In testing, this fixes the very common desync when using src/items/item_behaviors/jah_rakals_fury.gd.  Seemingly, the item property for the last creep targeted (stored in user_int) frequently differed between clients, but seemingly only because of id recycling rather than targeting differences

my understanding is that `get_instance_id()` isn't safe for multiplayer, but some places require it to summon object instances.  Fix the remaining places that don't summon object instances, revisit other approaches to fully eliminate  get_instance_id()